### PR TITLE
Add AGENTS.md with development environment documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Repository overview
+
+This is a **distribution-only repository** for **SingleBeatAnalysisApp**, a MATLAB-compiled standalone desktop GUI application for cardiac/beat analysis (Johns Hopkins University). The repository contains **no source code** — only pre-built application archives (`.zip` and `.7z`) for Mac and Windows.
+
+### Key constraints
+
+- **No buildable source code**: MATLAB `.m`/`.mlapp` source files are not in this repo. The actual development happens outside this repository.
+- **No package manager, tests, linting, or CI**: There is no `package.json`, `Makefile`, `requirements.txt`, test suite, or lint configuration.
+- **Cannot run the application in Cloud VMs**: The compiled binaries target Mac (`.app` bundles) and Windows (`.exe`). There is no Linux build. Additionally, MATLAB Runtime R2025a (~2GB+ proprietary) is required.
+- **No development workflow**: Changes to this repo are limited to adding/updating distribution archives and editing `README.md`.
+
+### What agents can do
+
+- Verify archive integrity: `unzip -t <file>.zip` for zip files.
+- Inspect archive contents: `unzip -l <file>.zip` to list files.
+- Read/edit `README.md` for documentation updates.
+- Add or replace distribution archive files.
+
+### What agents cannot do
+
+- Build, compile, or run the MATLAB application (no source code, no MATLAB Runtime).
+- Run tests or linting (none exist).
+- Start any development server or service.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` documenting the nature of this repository for future Cursor Cloud agents.

### Context

This repository is a **distribution-only repository** for the SingleBeatAnalysisApp MATLAB-compiled desktop application. It contains no source code, build system, package manager, tests, or development workflow — only pre-built application archives (`.zip`/`.7z`) for Mac and Windows.

### What was done

- Explored all 7 distribution archives and verified their integrity (all pass `unzip -t` checks)
- Examined build metadata confirming MATLAB Runtime R2025a dependency
- Created `AGENTS.md` documenting:
  - Repository is distribution-only (no source code)
  - No build, test, lint, or development workflow exists
  - Application requires MATLAB Runtime R2025a and targets Mac/Windows only
  - What agents can and cannot do in this repo

### Archive verification

All archives verified successfully:

[archive_verification.log](https://cursor.com/agents/bc-b7bd9ce9-2cdf-442d-a815-2a478a56943c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Farchive_verification.log)

### Why no dev environment setup

- No source code to build/run
- No tests or linting to execute  
- No package manager or dependencies to install
- Compiled binaries target Mac/Windows only (not Linux)
- MATLAB Runtime R2025a (proprietary, ~2GB+) required to run

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7bd9ce9-2cdf-442d-a815-2a478a56943c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7bd9ce9-2cdf-442d-a815-2a478a56943c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

